### PR TITLE
🔨 修復(System.php)：更改 getMaxUploadSize 方法的返回類型為字串

### DIFF
--- a/src/Model/System.php
+++ b/src/Model/System.php
@@ -22,7 +22,7 @@ class System
     }
 
     #[Field]
-    public function getMaxUploadSize(): int
+    public function getMaxUploadSize(): string
     {
         $max_size = -1;
         if ($max_size < 0) {
@@ -39,7 +39,7 @@ class System
                 $max_size = $upload_max;
             }
         }
-        return $max_size;
+        return Util::Size($max_size, ["binary" => true]);
     }
 
     #[Field]


### PR DESCRIPTION
🔄 重構(System.php)：使用 Util::Size 方法處理 getMaxUploadSize 方法的返回值