### PR TITLE
chore: add .env.example, CI and README notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Database
+DATABASE_HOSTNAME=127.0.0.1
+DATABASE_DATABASE=light
+DATABASE_USERNAME=root
+DATABASE_PASSWORD=changeme
+DATABASE_PORT=3306
+DATABASE_CHARSET=utf8mb4
+
+# JWT
+# Generate a random 32+ byte secret. Example (Linux/macOS):
+#   php -r "echo bin2hex(random_bytes(32));"
+JWT_SECRET=replace_with_a_strong_random_secret
+
+# Cookie settings
+COOKIE_DOMAIN=
+COOKIE_SECURE=true
+COOKIE_SAMESITE=Lax
+COOKIE_PARTITIONED=false
+
+# API prefix (if installed under subpath)
+API_PREFIX=
+
+# Google Sign-in
+GOOGLE_CLIENT_ID=
+
+# File system uploads public url
+FS_PUBLIC_URL=/api/uploads/

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,30 @@
+name: PHP CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: mbstring, xml
+      - name: Install composer dependencies
+        run: composer install --no-progress --prefer-dist --no-suggest
+      - name: Run PHPStan
+        run: |
+          if [ -f phpstan.neon ]; then
+            vendor/bin/phpstan analyse -l 5
+          fi
+      - name: Run tests
+        run: |
+          if [ -d tests ]; then
+            composer test
+          fi

--- a/README.md
+++ b/README.md
@@ -37,3 +37,31 @@ composer require google/apiclient
 ```ini
 GOOGLE_CLIENT_ID=
 ```
+
+Quick start
+-----------
+
+1. Copy .env.example to .env and fill values (especially DATABASE_ and JWT_SECRET):
+
+```bash
+cp .env.example .env
+# generate a strong JWT_SECRET (example):
+php -r "echo bin2hex(random_bytes(32));"
+```
+
+2. Install dependencies:
+
+```bash
+composer install
+```
+
+3. Run with PHP built-in server (development):
+
+```bash
+php -S 0.0.0.0:8080 -t public index.php
+```
+
+Notes on JWT_SECRET
+-------------------
+- The application uses HS256 for JWT by default. Use a strong random secret (at least 32 bytes hex) and keep it private.
+- For higher security consider using asymmetric keys (RS256) and storing private keys securely.


### PR DESCRIPTION
Adds .env.example, a basic GitHub Actions workflow for PHP checks, and README quick start + JWT notes.\n\nThis improves onboarding and CI for the project.